### PR TITLE
Fix for unused test dependency error

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -14,6 +14,6 @@ gpg --fast-import .travis/codesigning.asc
 ./mvnw deploy \
     --settings .travis/settings.xml \
     -P publish-artifacts \
-    -Dmaven.test.skip=true \
+    -DskipTests \
     --batch-mode \
     --show-version


### PR DESCRIPTION
During deploy we were getting the error because we were skipping the test compile.