### PR TITLE
Upgraded kotlin.version from 1.2.71 to 1.3.61

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
 
   <properties>
     <doxia.version>1.9</doxia.version>
-    <kotlin.version>1.2.71</kotlin.version>
-    <mockk.version>1.9.3.kotlin12</mockk.version>
+    <kotlin.version>1.3.61</kotlin.version>
+    <mockk.version>1.9.3</mockk.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Bumps `kotlin.version` from 1.2.71 to 1.3.61.