### PR TITLE
Removed sudo key from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@
 # #L%
 ###
 ---
-sudo: false
-
 dist: xenial
 
 language: java


### PR DESCRIPTION
The key `sudo` has no effect anymore.