### PR TITLE
Upgraded doxia.version from 1.9.1 to 1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.8.1</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.5.13</version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   <description>A kotlin DSL for outputting documentation using Doxia.</description>
 
   <properties>
-    <doxia.version>1.9.1</doxia.version>
+    <doxia.version>1.10</doxia.version>
     <kotlin.version>1.3.61</kotlin.version>
     <mockk.version>1.9.3</mockk.version>
   </properties>


### PR DESCRIPTION
Bumps `doxia.version` from 1.9.1 to 1.10.

Updates `doxia-core` from 1.9.1 to 1.10
- [Release notes](https://github.com/apache/maven-doxia/releases)
- [Commits](apache/maven-doxia@doxia-1.9.1...doxia-1.10)

Updates `doxia-sink-api` from 1.9.1 to 1.10
- [Release notes](https://github.com/apache/maven-doxia/releases)
- [Commits](apache/maven-doxia@doxia-1.9.1...doxia-1.10)