### PR TITLE
Upgrade to GitHub-native Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: io.mockk:mockk
+    versions:
+    - "> 1.9.3.kotlin12, < 1.9.4"
+  - dependency-name: io.mockk:mockk-dsl-jvm
+    versions:
+    - "> 1.9.3.kotlin12, < 1.9.4"
+  - dependency-name: org.jetbrains.kotlin:kotlin-maven-plugin
+    versions:
+    - "< 1.4, >= 1.3.a"
+  - dependency-name: org.jetbrains.kotlin:kotlin-reflect
+    versions:
+    - "< 1.4, >= 1.3.a"
+  - dependency-name: org.jetbrains.kotlin:kotlin-stdlib
+    versions:
+    - "< 1.4, >= 1.3.a"
+  - dependency-name: org.jetbrains.kotlin:kotlin-stdlib-jdk8
+    versions:
+    - "< 1.4, >= 1.3.a"
+  - dependency-name: org.jetbrains.kotlin:kotlin-test
+    versions:
+    - "< 1.4, >= 1.3.a"
+  - dependency-name: org.jetbrains.kotlin:kotlin-test-junit
+    versions:
+    - "< 1.4, >= 1.3.a"
+  - dependency-name: org.jetbrains.dokka:dokka-maven-plugin
+    versions:
+    - 1.4.20-dev-65

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,31 +6,3 @@ updates:
     interval: weekly
     day: saturday
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: io.mockk:mockk
-    versions:
-    - "> 1.9.3.kotlin12, < 1.9.4"
-  - dependency-name: io.mockk:mockk-dsl-jvm
-    versions:
-    - "> 1.9.3.kotlin12, < 1.9.4"
-  - dependency-name: org.jetbrains.kotlin:kotlin-maven-plugin
-    versions:
-    - "< 1.4, >= 1.3.a"
-  - dependency-name: org.jetbrains.kotlin:kotlin-reflect
-    versions:
-    - "< 1.4, >= 1.3.a"
-  - dependency-name: org.jetbrains.kotlin:kotlin-stdlib
-    versions:
-    - "< 1.4, >= 1.3.a"
-  - dependency-name: org.jetbrains.kotlin:kotlin-stdlib-jdk8
-    versions:
-    - "< 1.4, >= 1.3.a"
-  - dependency-name: org.jetbrains.kotlin:kotlin-test
-    versions:
-    - "< 1.4, >= 1.3.a"
-  - dependency-name: org.jetbrains.kotlin:kotlin-test-junit
-    versions:
-    - "< 1.4, >= 1.3.a"
-  - dependency-name: org.jetbrains.dokka:dokka-maven-plugin
-    versions:
-    - 1.4.20-dev-65


### PR DESCRIPTION
Legacy Dependabot is no longer available.