### PR TITLE
Upgraded commons-codec from 1.11 to 1.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>com.github.gantsign.parent</groupId>
     <artifactId>kotlin-parent</artifactId>
     <version>2.16.0</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <groupId>com.github.gantsign.maven.doxia</groupId>
@@ -44,6 +44,11 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>1.15</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
@@ -149,13 +154,13 @@
                   <version>[1.8,1.9)</version>
                 </requireJavaVersion>
                 <!-- When there are multiple versions of a dependency you have to choose which one to use. -->
-                <dependencyConvergence />
+                <dependencyConvergence/>
                 <requireReleaseDeps>
                   <message>No Snapshots Allowed!</message>
                   <onlyWhenRelease>true</onlyWhenRelease>
                 </requireReleaseDeps>
                 <!-- When there are multiple versions of a dependency you have to choose the maximum version. -->
-                <requireUpperBoundDeps />
+                <requireUpperBoundDeps/>
                 <requirePluginVersions>
                   <message>Best Practice is to always define plugin versions!</message>
                   <banLatest>true</banLatest>


### PR DESCRIPTION
To fix: https://security.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518