### PR TITLE
Resolved deprecated default method config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
         <artifactId>kotlin-maven-plugin</artifactId>
         <configuration>
           <args>
-            <arg>-Xjvm-default=enable</arg>
+            <arg>-Xjvm-default=all</arg>
           </args>
         </configuration>
       </plugin>

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/AnchorContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/AnchorContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface AnchorContainer {
     val sink: Sink
 
-    @JvmDefault
     fun anchor(
         name: String,
         id: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/AuthorContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/AuthorContainer.kt
@@ -26,7 +26,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface AuthorContainer {
     val sink: Sink
 
-    @JvmDefault
     fun author(email: String = "", init: Author.() -> Unit) {
         sink.author(
             attributesOf(

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/BodyContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/BodyContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface BodyContainer {
     val sink: Sink
 
-    @JvmDefault
     fun body(
         id: String = "",
         cssClass: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/CommentContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/CommentContainer.kt
@@ -24,7 +24,6 @@ import org.apache.maven.doxia.sink.Sink
 interface CommentContainer {
     val sink: Sink
 
-    @JvmDefault
     fun comment(supplier: () -> String) {
         sink.comment(supplier())
     }

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/DateContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/DateContainer.kt
@@ -24,7 +24,6 @@ import org.apache.maven.doxia.sink.Sink
 interface DateContainer {
     val sink: Sink
 
-    @JvmDefault
     fun date(init: Date.() -> Unit) {
         sink.date()
         init(Date(sink))

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/DefinedTermContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/DefinedTermContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface DefinedTermContainer {
     val sink: Sink
 
-    @JvmDefault
     fun definedTerm(
         id: String = "",
         cssClass: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/DefinitionContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/DefinitionContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface DefinitionContainer {
     val sink: Sink
 
-    @JvmDefault
     fun definition(
         id: String = "",
         cssClass: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/DefinitionListContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/DefinitionListContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface DefinitionListContainer {
     val sink: Sink
 
-    @JvmDefault
     fun definitionList(
         id: String = "",
         cssClass: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/DefinitionListItemContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/DefinitionListItemContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface DefinitionListItemContainer {
     val sink: Sink
 
-    @JvmDefault
     fun listItem(
         id: String = "",
         cssClass: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/FigureCaptionContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/FigureCaptionContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface FigureCaptionContainer {
     val sink: Sink
 
-    @JvmDefault
     fun caption(
         id: String = "",
         cssClass: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/FigureContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/FigureContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface FigureContainer {
     val sink: Sink
 
-    @JvmDefault
     fun figure(
         id: String = "",
         cssClass: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/FigureGraphicsContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/FigureGraphicsContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface FigureGraphicsContainer {
     val sink: Sink
 
-    @JvmDefault
     fun figureGraphics(
         src: String,
         alt: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/HeadContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/HeadContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface HeadContainer {
     val sink: Sink
 
-    @JvmDefault
     fun head(
         lang: String = "",
         profile: List<URL> = listOf(),

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/HorizontalRuleContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/HorizontalRuleContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface HorizontalRuleContainer {
     val sink: Sink
 
-    @JvmDefault
     fun horizontalRule(
         align: String = "",
         noShade: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/LineBreakContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/LineBreakContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface LineBreakContainer {
     val sink: Sink
 
-    @JvmDefault
     fun lineBreak(
         id: String = "",
         cssClass: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/LinkContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/LinkContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface LinkContainer {
     val sink: Sink
 
-    @JvmDefault
     fun link(
         name: String,
         id: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/NonBreakingSpaceContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/NonBreakingSpaceContainer.kt
@@ -24,7 +24,6 @@ import org.apache.maven.doxia.sink.Sink
 interface NonBreakingSpaceContainer {
     val sink: Sink
 
-    @JvmDefault
     fun nonBreakingSpace() {
         sink.nonBreakingSpace()
     }

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/NumberedListContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/NumberedListContainer.kt
@@ -28,7 +28,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface NumberedListContainer {
     val sink: Sink
 
-    @JvmDefault
     fun numberedList(
         numberingStyle: NumberingStyle,
         id: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/NumberedListItemContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/NumberedListItemContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface NumberedListItemContainer {
     val sink: Sink
 
-    @JvmDefault
     fun listItem(
         id: String = "",
         cssClass: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/PageBreakContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/PageBreakContainer.kt
@@ -24,7 +24,6 @@ import org.apache.maven.doxia.sink.Sink
 interface PageBreakContainer {
     val sink: Sink
 
-    @JvmDefault
     fun pageBreak() {
         sink.pageBreak()
     }

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/ParagraphContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/ParagraphContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface ParagraphContainer {
     val sink: Sink
 
-    @JvmDefault
     fun paragraph(
         align: String = "",
         id: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/RawTextContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/RawTextContainer.kt
@@ -24,7 +24,6 @@ import org.apache.maven.doxia.sink.Sink
 interface RawTextContainer {
     val sink: Sink
 
-    @JvmDefault
     fun rawText(supplier: () -> String) {
         sink.rawText(supplier())
     }

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/SectionContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/SectionContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface SectionContainer {
     val sink: Sink
 
-    @JvmDefault
     fun section(
         level: Int,
         id: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TableCaptionContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TableCaptionContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface TableCaptionContainer {
     val sink: Sink
 
-    @JvmDefault
     fun tableCaption(
         align: String = "",
         id: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TableCellContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TableCellContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface TableCellContainer {
     val sink: Sink
 
-    @JvmDefault
     fun tableCell(
         abbvr: String = "",
         align: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TableContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TableContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface TableContainer {
     val sink: Sink
 
-    @JvmDefault
     fun table(
         align: String = "",
         bgColor: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TableHeaderCellContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TableHeaderCellContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface TableHeaderCellContainer {
     val sink: Sink
 
-    @JvmDefault
     fun tableHeaderCell(
         abbvr: String = "",
         align: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TableRowContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TableRowContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface TableRowContainer {
     val sink: Sink
 
-    @JvmDefault
     fun tableRow(
         align: String = "",
         bgColor: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TableRowsContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TableRowsContainer.kt
@@ -25,7 +25,6 @@ import org.apache.maven.doxia.sink.Sink
 interface TableRowsContainer {
     val sink: Sink
 
-    @JvmDefault
     fun tableRows(
         grid: Boolean = false,
         vararg justification: Justify = emptyArray(),

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TextContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TextContainer.kt
@@ -29,7 +29,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface TextContainer {
     val sink: Sink
 
-    @JvmDefault
     fun text(
         vAlign: VAlign? = null,
         decoration: Decoration? = null,
@@ -54,7 +53,6 @@ interface TextContainer {
         )
     }
 
-    @JvmDefault
     operator fun String.unaryPlus() {
         sink.text(this)
     }

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TitleContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/TitleContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface TitleContainer {
     val sink: Sink
 
-    @JvmDefault
     fun title(
         id: String = "",
         cssClass: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/UnorderedListContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/UnorderedListContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface UnorderedListContainer {
     val sink: Sink
 
-    @JvmDefault
     fun list(
         id: String = "",
         cssClass: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/UnorderedListItemContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/UnorderedListItemContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface UnorderedListItemContainer {
     val sink: Sink
 
-    @JvmDefault
     fun listItem(
         id: String = "",
         cssClass: String = "",

--- a/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/VerbatimContainer.kt
+++ b/src/main/kotlin/com/github/gantsign/maven/doxia/sink/kotlin/content/VerbatimContainer.kt
@@ -27,7 +27,6 @@ import org.apache.maven.doxia.sink.SinkEventAttributes
 interface VerbatimContainer {
     val sink: Sink
 
-    @JvmDefault
     fun verbatim(
         decoration: String = "",
         align: String = "",


### PR DESCRIPTION
`@JvmDefault` was deprecated in Kotlin 1.6.