### PR TITLE
Fix Maven version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kotlin Extensions for Doxia
 
 [![Release](https://github.com/gantsign/doxia-sink-api-ktx/workflows/Build/badge.svg)](https://github.com/gantsign/doxia-sink-api-ktx/actions?query=workflow%3ABuild)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.gantsign.maven.doxia/doxia-sink-api-ktx/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.gantsign.maven.doxia/doxia-sink-api-ktx)
+[![Maven Central](https://img.shields.io/maven-central/v/com.github.gantsign.maven.doxia/doxia-sink-api-ktx?logo=apachemaven&label=Maven%20Central)](https://central.sonatype.com/artifact/com.github.gantsign.maven.doxia/doxia-sink-api-ktx)
 [![codecov](https://codecov.io/gh/gantsign/doxia-sink-api-ktx/branch/main/graph/badge.svg)](https://codecov.io/gh/gantsign/doxia-sink-api-ktx)
 [![Known Vulnerabilities](https://snyk.io/test/github/gantsign/doxia-sink-api-ktx/badge.svg)](https://snyk.io/test/github/gantsign/doxia-sink-api-ktx)
 


### PR DESCRIPTION
Looks like `maven-badges.herokuapp.com` has been decommissioned.